### PR TITLE
Add field type to generated customMetadata xml file

### DIFF
--- a/src/commands/cmdt/csv/convert.ts
+++ b/src/commands/cmdt/csv/convert.ts
@@ -137,7 +137,7 @@ export default class Convert extends SfdxCommand {
             const values = xml.ele('values');
             values.ele('field', key);
             if (csvRow[key]){
-                values.ele('value', { 'xsi:type': `xsd:${this.getCustomMetadataXsiType(key)}` }, csvRow[key]);
+                values.ele('value', { 'xsi:type': `xsd:${this.getCustomMetadataXsiType(this.fullNameToTypeMap.get(key))}` }, csvRow[key]);
             } else {
                 values.ele('value', { 'xsi:nil': true})
             }       


### PR DESCRIPTION
マッピングファイル無しでcmdt:csv:convertを実行した場合、カスタムメタデータの項目型によらず
項目のTypeがString型となっていた点の修正